### PR TITLE
Avoid macOS-specific deadlock between AWT & JavaFX

### DIFF
--- a/src/main/java/sc/fiji/filamentdetector/gui/controller/ImagePreprocessorsController.java
+++ b/src/main/java/sc/fiji/filamentdetector/gui/controller/ImagePreprocessorsController.java
@@ -36,6 +36,7 @@ import org.scijava.Context;
 import org.scijava.event.EventService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
+import org.scijava.thread.ThreadService;
 import org.scijava.ui.UIService;
 
 import javafx.beans.value.ChangeListener;
@@ -83,6 +84,9 @@ public class ImagePreprocessorsController extends AbstractController implements 
 
 	@Parameter
 	private LogService log;
+
+	@Parameter
+	private ThreadService threadService;
 
 	@Parameter
 	private GUIStatusService status;
@@ -291,7 +295,9 @@ public class ImagePreprocessorsController extends AbstractController implements 
 						.orElse(null);
 
 				if (imageDisplay == null) {
-					ui.show(dataset);
+					// NB: We defer to the EDT to avoid a macOS-specific deadlock between
+					// AWT and JavaFX. See https://github.com/hadim/FilamentDetector#12.
+					threadService.queue(() -> ui.show(dataset));
 					imageDisplay = ids.getImageDisplays().stream()
 							.filter(imd -> ((Dataset) imd.getActiveView().getData()).equals(dataset)).findFirst()
 							.orElse(null);


### PR DESCRIPTION
Specifically, the program hangs when the "Preprocess image" button is pressed. See #12.

The issue is a macOS-specific deadlock caused by JavaFX. Others have reported very similar issues ([1](https://stackoverflow.com/questions/31861900/deadlock-between-different-event-threads), [2](https://bugs.openjdk.java.net/browse/JDK-8087465)).

Here is the dump of the relevant threads:
```
"AWT-EventQueue-0" #19 prio=6 os_prio=31 tid=0x00007f87204e0000 nid=0x6d27 runnable [0x0000700009f79000]
   java.lang.Thread.State: RUNNABLE
	at sun.awt.CGraphicsDevice.nativeGetScreenInsets(Native Method)
	at sun.awt.CGraphicsDevice.getScreenInsets(CGraphicsDevice.java:128)
	at sun.lwawt.macosx.LWCToolkit.getScreenInsets(LWCToolkit.java:407)
	at java.awt.Window.init(Window.java:506)
	at java.awt.Window.<init>(Window.java:537)
	at java.awt.Frame.<init>(Frame.java:420)
	at ij.gui.ImageWindow.<init>(ImageWindow.java:68)
	at ij.gui.ImageWindow.<init>(ImageWindow.java:64)
	at ij.ImagePlus.show(ImagePlus.java:432)
	at ij.ImagePlus.show(ImagePlus.java:403)
	at net.imagej.legacy.display.LegacyImageDisplayViewer.view(LegacyImageDisplayViewer.java:116)
	at net.imagej.legacy.ui.LegacyUI$1.run(LegacyUI.java:197)
	at org.scijava.thread.DefaultThreadService.invoke(DefaultThreadService.java:114)
	at net.imagej.legacy.ui.LegacyUI.show(LegacyUI.java:193)
	at org.scijava.ui.DefaultUIService.onEvent(DefaultUIService.java:381)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.scijava.event.DefaultEventService$ProxySubscriber.onEvent(DefaultEventService.java:301)
	at org.scijava.event.DefaultEventService$ProxySubscriber.onEvent(DefaultEventService.java:275)
	at org.bushe.swing.event.ThreadSafeEventService.publish(ThreadSafeEventService.java:971)
	at org.scijava.event.DefaultEventBus.access$101(DefaultEventBus.java:57)
	at org.scijava.event.DefaultEventBus$1.run(DefaultEventBus.java:191)
	at org.scijava.thread.DefaultThreadService$2.run(DefaultThreadService.java:221)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:301)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

"JavaFX Application Thread" #10 daemon prio=5 os_prio=31 tid=0x00007f871bfda000 nid=0x307 in Object.wait() [0x00007ffeee592000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at java.awt.EventQueue.invokeAndWait(EventQueue.java:1343)
	- locked <0x00000007186c46b0> (a java.awt.EventQueue$1AWTInvocationLock)
	at java.awt.EventQueue.invokeAndWait(EventQueue.java:1324)
	at org.scijava.thread.DefaultThreadService.invoke(DefaultThreadService.java:118)
	at org.scijava.event.DefaultEventBus.publishNow(DefaultEventBus.java:185)
	at org.scijava.event.DefaultEventBus.publishNow(DefaultEventBus.java:76)
	at org.scijava.event.DefaultEventService.publish(DefaultEventService.java:105)
	at org.scijava.display.DefaultDisplayService.createDisplay(DefaultDisplayService.java:216)
	at org.scijava.ui.AbstractUserInterface.show(AbstractUserInterface.java:101)
	at org.scijava.ui.UserInterface.show(UserInterface.java:78)
	at org.scijava.ui.DefaultUIService.show(DefaultUIService.java:238)
	at sc.fiji.filamentdetector.gui.controller.ImagePreprocessorsController.usePreprocessedImageForOverlay(ImagePreprocessorsController.java:294)
	at sc.fiji.filamentdetector.gui.controller.ImagePreprocessorsController.access$000(ImagePreprocessorsController.java:77)
	at sc.fiji.filamentdetector.gui.controller.ImagePreprocessorsController$2.succeeded(ImagePreprocessorsController.java:254)
	at javafx.concurrent.Task.setState(Task.java:724)
	at javafx.concurrent.Task$TaskCallable.lambda$call$501(Task.java:1434)
	at javafx.concurrent.Task$TaskCallable$$Lambda$330/1486809162.run(Unknown Source)
	at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
	at com.sun.javafx.application.PlatformImpl$$Lambda$213/1589294818.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
	at com.sun.javafx.application.PlatformImpl$$Lambda$212/1332539422.run(Unknown Source)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
```

The fix presented here simply offloads the `ui.show` call to the AWT Event Dispatch Thread. Then when `EventService.publishNow` occurs, the `ThreadService.invoke` simply performs the event delivery immediately, instead of using `EventQueue.invokeAndWait` and hosing everything up.

I do not think this is an ideal solution by any means. But it makes the problem go away in this instance.